### PR TITLE
Update openemr_ecs_stack.py (upgrades OpenEMR to v7.0.4)

### DIFF
--- a/openemr_ecs/openemr_ecs_stack.py
+++ b/openemr_ecs/openemr_ecs_stack.py
@@ -107,7 +107,7 @@ class OpenemrEcsStack(Stack):
         self.lambda_python_runtime = _lambda.Runtime.PYTHON_3_14
 
         # Use the second-latest tagged version for the "openemr/openemr" docker container (this is the stable version).
-        self.openemr_version = "7.0.3"
+        self.openemr_version = "7.0.4"
 
         ###############################################################################################
         # The following are functions that create AWS resources that will be managed by CloudFormation


### PR DESCRIPTION
This PR updates OpenEMR to v7.0.4 (would recommend and would like to please request we do a release after the PR is merged to v2.0.0 as I don't think this release could be considered "compatible" with previous releases and thus has to be a "major" release rather than a "minor" one).