### PR TITLE
fix: remove invalid 'base' input from codecov-action v5 steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
           fail_ci_if_error: false
           override_branch: ${{ github.ref_name }}
           override_commit: ${{ github.event.pull_request.head.sha || github.sha }}
-          base: ${{ github.base_ref || 'main' }}
           slug: ${{ github.repository }}
 
       - name: Upload coverage HTML report
@@ -110,7 +109,6 @@ jobs:
           fail_ci_if_error: false
           override_branch: ${{ github.ref_name }}
           override_commit: ${{ github.event.pull_request.head.sha || github.sha }}
-          base: ${{ github.base_ref || 'main' }}
           slug: ${{ github.repository }}
 
   cdk-synth:


### PR DESCRIPTION
The codecov/codecov-action@v5 steps in the unit test and credential rotation test jobs were using a base parameter that isn't a valid input for v5 of the action. This produced "Unexpected input(s) 'base'" warnings on every CI run. Removed it from both steps — the action already infers the comparison base from override_branch and override_commit.